### PR TITLE
Mjswrapper tweaks

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -11,8 +11,8 @@
     "dev": "concurrently \"npm run sass\" \"npm start\""
   },
   "keywords": [],
-  "author": "",
-  "license": "ISC",
+  "author": "StevenKT",
+  "license": "GPLv3",
   "devDependencies": {
     "@babel/core": "^7.8.4",
     "@babel/preset-env": "^7.8.4",
@@ -39,5 +39,9 @@
     "react-router-dom": "^5.1.2",
     "shortid": "^2.2.15",
     "simplex-noise": "^2.4.0"
+  },
+  "engines": {
+    "node": ">=10.0.0",
+    "npm": ">=6.0.0"
   }
 }

--- a/client/package.json
+++ b/client/package.json
@@ -12,7 +12,7 @@
   },
   "keywords": [],
   "author": "StevenKT",
-  "license": "GPLv3",
+  "license": "LGPLv3",
   "devDependencies": {
     "@babel/core": "^7.8.4",
     "@babel/preset-env": "^7.8.4",

--- a/client/src/components/p5/sketches/orgTest.js
+++ b/client/src/components/p5/sketches/orgTest.js
@@ -19,7 +19,7 @@ const testSketch = (p) => {
   var startStopEngine;
   var startStopEngineBool = true;
 
-  var framesContainer = new Array(30).fill(30);
+  var framesContainer = new Array(15).fill(60);
 
   p.setup = () => {
     p.disableFriendlyErrors = true;
@@ -60,7 +60,7 @@ const testSketch = (p) => {
     
     if (startStopEngineBool) {
       orgEnv.updateEnv();
-      orgEnv.mjsi.nextTick(p.millis() / p.getFrameRate())
+      orgEnv.mjsi.smoothUpdate(1100 / avgFrameRate())
     }
 
   
@@ -73,6 +73,7 @@ const testSketch = (p) => {
     if (recording) {
       capturer.capture(document.getElementById("defaultCanvas0"))
     }
+
   }
 
   function debugNextFrame() {
@@ -91,8 +92,8 @@ const testSketch = (p) => {
   }
 
   function avgFrameRate() {
-    framesContainer[p.frameCount % 30] = p.frameRate();
-    return framesContainer.reduce((a, b) => a + b, 0) / 30;
+    framesContainer[p.frameCount % 15] = p.frameRate();
+    return framesContainer.reduce((a, b) => a + b, 0) / 15;
   }
 
 

--- a/client/src/components/p5/sketches/orgTest.js
+++ b/client/src/components/p5/sketches/orgTest.js
@@ -1,5 +1,6 @@
 import OrgEnv from "../../../libs/classes/org-env/orgEnv";
 import { CS } from "./orgConfig";
+import MJSW from "../../../libs/classes/MJSWrapper";
 
 import CCapture from "ccapture.js";
 
@@ -46,7 +47,6 @@ const testSketch = (p) => {
     orgEnv = new OrgEnv(p, CS.w, CS.h);
     orgEnv.addNOrgs(50);
 
-    // orgEnv.mjsi.run()
   }
 
   p.draw = () => {
@@ -55,12 +55,11 @@ const testSketch = (p) => {
       startRecording = false;
     }
 
-    p.background(0);
-    orgEnv.drawOrgs();
-    
     if (startStopEngineBool) {
+      MJSW.smoothUpdate(1100 / avgFrameRate())
       orgEnv.updateEnv();
-      orgEnv.mjsi.smoothUpdate(1100 / avgFrameRate())
+      p.background(0);
+      orgEnv.drawOrgs();
     }
 
   
@@ -77,8 +76,10 @@ const testSketch = (p) => {
   }
 
   function debugNextFrame() {
+    MJSW.smoothUpdate(1100 / avgFrameRate())
     orgEnv.updateEnv();
-    orgEnv.mjsi.nextTick(p.frameRate() / 60)
+    p.background(0);
+    orgEnv.drawOrgs();
   }
 
   function start_stop() {

--- a/client/src/libs/classes/MJSWrapper.js
+++ b/client/src/libs/classes/MJSWrapper.js
@@ -6,14 +6,14 @@ const World = mjs.World;
 const Constraint = mjs.Constraint;
 const Engine = mjs.Engine;
 const Composite = mjs.Composite;
+const Events = mjs.Events;
 // const Runner = mjs.Runner;
-// const Events = mjs.Events;
 // const Common = mjs.Common;
 
 const TAU = Math.PI * 2;
 const PI = Math.PI;
 
-export class MJSWrapper {
+class MJSWrapper {
   constructor() {
     this.engine = Engine.create();
     this.world = this.engine.world;
@@ -27,6 +27,14 @@ export class MJSWrapper {
     this.Runner = mjs.Runner;
     this.Events = mjs.Events;
     this.Common = mjs.Common;
+  }
+
+  eventsOn(condition, cb) {
+    Events.on(this.engine, condition, cb);
+  }
+
+  setGravityY(val) {
+    this.world.gravity.y = val;
   }
 
   upTime() {
@@ -156,7 +164,6 @@ export class MJSWrapper {
     this.engine.enabled = false;
   }
 
-  static
   setVelocity(body, vecV) {
     Body.setVelocity(body, vecV);
   }
@@ -166,7 +173,6 @@ export class MJSWrapper {
     Body.applyForce(body, body.position, vecF)
   }
 
-  static
   getApplyForceToCenter(body) {
     return function(vecF) {
       Body.applyForce(body, body.position, vecF)
@@ -190,3 +196,6 @@ export class MJSWrapper {
   }
 
 }
+
+const MJSW = new MJSWrapper();
+export default MJSW;

--- a/client/src/libs/classes/matterHelpers.js
+++ b/client/src/libs/classes/matterHelpers.js
@@ -6,9 +6,9 @@ const World = mjs.World;
 const Constraint = mjs.Constraint;
 const Engine = mjs.Engine;
 const Composite = mjs.Composite;
-const Runner = mjs.Runner;
-const Events = mjs.Events;
-const Common = mjs.Common;
+// const Runner = mjs.Runner;
+// const Events = mjs.Events;
+// const Common = mjs.Common;
 
 const TAU = Math.PI * 2;
 const PI = Math.PI;
@@ -16,8 +16,8 @@ const PI = Math.PI;
 export class MJSWrapper {
   constructor() {
     this.engine = Engine.create();
-    this.runner = Runner.create();
     this.world = this.engine.world;
+    this.lastDelta = 60;
 
     this.Body = mjs.Body;
     this.World = mjs.World;
@@ -33,8 +33,9 @@ export class MJSWrapper {
     return this.engine.timing.timestamp;
   }
 
-  nextTick(delta) {
-    Runner.tick(this.runner, this.engine, delta);
+  smoothUpdate(delta) {
+    Engine.update(this.engine, delta, delta/this.lastDelta)
+    this.lastDelta = delta;
   }
 
   createComposite(options) {
@@ -44,8 +45,7 @@ export class MJSWrapper {
   }
 
   addToComposite(composite, ...elements) {
-    Composite.add(composite, ...elements)
-    return composite  
+    Composite.add(composite, ...elements) 
   }
 
   addConstraint(options, composite=null) {
@@ -141,7 +141,7 @@ export class MJSWrapper {
     }
 
     return [segments, constraints]
-  } 
+  }
 
   setWorldBounds(w, h, boundsThickness) {
     this.bounds = this.constructor.getBounds(w, h, boundsThickness)

--- a/client/src/libs/classes/org-env/orgEnv.js
+++ b/client/src/libs/classes/org-env/orgEnv.js
@@ -1,24 +1,19 @@
-import shortid from "shortid";
 
-import { MJSWrapper } from "../matterHelpers";
+
+import MJSW from "../MJSWrapper";
 import { boundsThickness } from "./orgEnv-config";
-import xorshiro128 from "../../PRNG/xoshiro128";
 import Org from "../org/org";
-
+import xorshiro128 from "../../PRNG/xoshiro128";
 const prng = xorshiro128('orgEnv');
-shortid.seed(666);
-
 
 class OrgEnv {
   constructor(p, w, h) {
     this.p = p;
     this.w = w;
     this.h = h;
-    this.mjsi = new MJSWrapper();
-    this.idGen = shortid.generate;
 
-    this.mjsi.world.gravity.y = 0;
-    this.mjsi.setWorldBounds(w, h, boundsThickness);
+    MJSW.setGravityY(0);
+    MJSW.setWorldBounds(w, h, boundsThickness);
     this.organisms = [];
 
     this.setupEvents();
@@ -27,8 +22,8 @@ class OrgEnv {
   addNOrgs(n) {
     let orgs = [];
     while (orgs.length < n) {
-      let uniqId = this.idGen();
-      let org = new Org(...this.randXY(), this.mjsi, this.p, uniqId);
+
+      let org = new Org(...this.randXY(), this.p);
       if (OrgEnv.overlaps(org, orgs)) {
         org.die();
       } else {
@@ -57,7 +52,7 @@ class OrgEnv {
   }
 
   setupEvents() {
-    this.mjsi.Events.on(this.mjsi.engine, 'collisionStart', (event) => {
+    MJSW.eventsOn('collisionStart', (event) => {
       let pairs = event.pairs.filter(pair => {
         return pair.bodyA.owner != pair.bodyB.owner
           && pair.bodyA.owner && pair.bodyB.owner
@@ -70,7 +65,7 @@ class OrgEnv {
   }
 
   // setupEvents() {
-  //   this.mjsi.Events.on(this.mjsi.engine, 'collisionStart', (event) => {
+  //   MJSW.Events.on(MJSW.engine, 'collisionStart', (event) => {
   //     let pairs = this.uniqPairs(event.pairs)
 
   //     for (let pair of pairs) {

--- a/client/src/libs/classes/org/gene-func.js
+++ b/client/src/libs/classes/org/gene-func.js
@@ -1,6 +1,6 @@
 // Gene types, red, green, black, gray, yellow, blue, cyan, white 
 import { cellScale, GeneDefaults, colorCodes } from "./org-cfg";
-import { MJSWrapper } from "../matterHelpers";
+import MJSW from "../MJSWrapper";
 
 import xorshiro128 from "../../PRNG/xoshiro128";
 const prng = xorshiro128('gene-func');
@@ -95,7 +95,7 @@ function YellowExpression({ length }) {
 
 function CyanExpression({ length, parentCell }) {
   var lim = GeneDefaults.maxVel * (length / (1 + length));
-  const applyForce = MJSWrapper.getApplyForceToCenter(parentCell.nucleus.body)
+  const applyForce = MJSW.getApplyForceToCenter(parentCell.nucleus.body)
   let activation = {
     active: {
       cyan: {
@@ -105,7 +105,7 @@ function CyanExpression({ length, parentCell }) {
           let dy = parentCell.pos.y - this.otherCell.pos.y;
           let fNorm = GeneDefaults.recoilVel / Math.sqrt(dx * dx + dy * dy);
           let vecV = { x: dx * fNorm, y: dy * fNorm };
-          MJSWrapper.setVelocity(parentCell.nucleus.body, vecV);
+          MJSW.setVelocity(parentCell.nucleus.body, vecV);
 
           parentCell.dEvents.cyan = 10;
         },

--- a/client/src/libs/classes/org/org.js
+++ b/client/src/libs/classes/org/org.js
@@ -1,5 +1,7 @@
 import cloneDeep from "lodash.clonedeep";
+import shortid from "shortid";
 
+import MJSW from "../MJSWrapper";
 import {
   randBaseGeneColor, randGeneColor, randNumGenes, minBodySize, cellScale,
   baseColors, cellBodyDefaults, randGeneLength, cellDefaults, wallDefaults
@@ -7,137 +9,40 @@ import {
 
 import newExpression from "./gene-func";
 
+shortid.seed(666);
+const idGen = shortid.generate;
+
+
 class Org {
-  constructor(x = 0, y = 0, mjsi, p, uniqId) {
+  constructor(x = 0, y = 0, p) {
+    this.id = idGen();
+    Object.assign(this, {p}, cellDefaults)
+    this.composite = MJSW.createComposite({ label: 'cell' });
 
-    Object.assign(this, {p, mjsi, id: uniqId}, cellDefaults)
-    this.composite = this.mjsi.createComposite({ label: 'cell' });
-
-    this.genes = this.getNewGenes();
-
-    this.nucleus = this.getNewNucleus(x, y)
-    this.expressions = this.getNewExpressions()
-    this.wall = this.getNewWall();
-
+    this.constructor.buildOrg(x, y, this);
     this.pos = this.nucleus.body.position;
     this.diameter = this.nucleus.r * 2;
 
     this.setBase(); // Set the baseGene name as well as actual colors to be painted.
     // baseGene, baseColor, cytoColor, nuclColor
-    this.eventPaint = null; // After an orgEvent will be filled with colors for the next draw event.
-    
-    this.defaultState = this.getNewDefaultState();
+
     this.passiveEvents = [];
     this.activeEvents = [];
     this.dEvents = {};
+
     // Time of creation
     this.dead = false;
     this.creationTime = p.millis();
-
   }
 
-
-
-
-  getNewGenes() {
-    let numSegments = randNumGenes(); // Get the number of gene segments to create.
-
-    let genes = { // Setup inital genes object
-      numSegments: numSegments,
-      segments: new Array(numSegments)
-    }
-
-    let gene = null, n = 0; // Getting the rest of the genes.
-    while (n < numSegments-1) {
-      gene = randGeneColor();
-      if (true || gene == genes.segments[0].color || !baseColors.has(gene)) { // Currently disabled
-        genes.segments[n] = { color: gene, length: randGeneLength() };
-        n += 1;
-      }
-    }
-    genes.segments[n] = {
-      color: randBaseGeneColor(),
-      length: randGeneLength()
-    }
-
-    genes['totalGenesLength'] = genes.segments  // Get total genes length;
-      .reduce((total, gene) => total + gene.length, 0)
-
-    genes['avgGeneArea'] = Math.sqrt(genes.segments // Get avg gene area.
-      .reduce((total, gene) => total + gene.length * gene.length, 0))
-
-    return genes;
+  static buildOrg(x, y, org) {
+    org.genes = Org.getNewGenes();
+    org.nucleus = Org.getNewNucleus(x, y, org);
+    org.expressions = Org.getNewExpressions(org);
+    org.wall = Org.getNewWall(org);
+    org.defaultState = Org.getNewDefaultState(org);
   }
 
-  getNewNucleus(x, y) {
-    let avgGeneArea = this.genes.avgGeneArea
-    let bodyRadius = avgGeneArea * 2 < minBodySize ? minBodySize : avgGeneArea;
-    bodyRadius = cellScale * bodyRadius;
-
-    return {
-      body: this.mjsi.addCircle(
-        { x: x, y: y, r: bodyRadius,
-          composite: this.composite, owner: this,
-          options: {...cellBodyDefaults, label: 'nucleus' }
-        }
-      ), 
-      r: bodyRadius
-    }
-  }
-
-  getNewExpressions() {
-    let aggregate = {};
-    for (let i = 0; i < this.genes.numSegments; i++) {
-      let { color, length } = this.genes.segments[i];
-      if (color in aggregate) {
-        aggregate[color].length += length;
-        aggregate[color].n += 1;
-      }
-      else {
-        aggregate[color] = {length: length, n: 1}
-      }
-    }
-
-    let expressions = {};
-    for (const [color, exp] of Object.entries(aggregate)) {
-      exp.avgLength = exp.length / exp.n;
-      let expBody = this.mjsi.addCircle({
-        x: this.nucleus.body.position.x,
-        y: this.nucleus.body.position.y,
-        r: cellScale * exp.avgLength,
-        composite: this.composite, owner: this,
-        options: { mass: 0, label: 'expression-' + color }
-      })
-
-      // we need to get the rest of the object...
-      let completeExp = newExpression(color, exp, expBody, this);
-      expressions[color] = completeExp;
-    }
-
-    return expressions;
-  }
-
-  getNewWall() {
-    let offset = 5;
-    let r = Math.max(...Object.values(this.expressions)
-      .map(exp => exp.avgLength)) + this.nucleus.r + offset + 5;
-
-    let[segments, constraints] = this.mjsi.addSoftCircle({
-      x: this.nucleus.body.position.x,
-      y: this.nucleus.body.position.y,
-      r: r,
-      owner: this, composite: this.composite,
-      ...wallDefaults
-    })
-    
-    let wall = {
-      segments: segments,
-      constraints: constraints,
-      r: r,
-    }
-
-    return wall;
-  }
 
   setBase() {
     this.baseGene = this.genes.segments[0].color;
@@ -146,45 +51,9 @@ class Org {
     this.nuclColor = [...this.baseColor, 225];
   }
 
-  getNewDefaultState() {
-    let passive = {};
-    let active = {};
-    for (let exp of Object.values(this.expressions)) {
-      passive = Object.assign({}, passive, exp.activation.passive);
-      active = Object.assign({}, active, exp.activation.active);
-    }
-    return { active: active, passive: passive };
-  }
-
   die() {
-    this.mjsi.removeBody(this.composite);
+    MJSW.removeBody(this.composite);
     this.dead = true;
-  }
-
-  static
-  orgEvent(orgA, orgB) {
-
-    // let aE = {};
-    // let bE = {};
-    // for (let [color, exp] of Object.entries(orgA.defaultState.active)) {
-    //   aE[color] = Object.assign({}, exp);
-    // }
-    // for (let [color, exp] of Object.entries(orgB.defaultState.active)) {
-    //   bE[color] = Object.assign({}, exp);
-    // }
-
-    // console.log(Object.entries(orgA.defaultState.active))
-    // let aE = Object.assign({}, ...orgA.defaultState.active);
-    // let bE = Object.assign({}, ...orgB.defaultState.active); 
-    
-    let aE = cloneDeep(orgA.defaultState.active);
-    let bE = cloneDeep(orgB.defaultState.active);
-
-    for (let activation of Object.values(aE)) activation.setup(orgB, bE);
-    for (let activation of Object.values(bE)) activation.setup(orgA, aE);
-
-    orgA.activeEvents.push(...Object.values(aE));
-    orgB.activeEvents.push(...Object.values(bE));
   }
 
   update() {
@@ -194,7 +63,6 @@ class Org {
       this.die();
       return true;
     }
-
 
     // Update active events;
     for (let i = 0; i < this.activeEvents.length; i++) {
@@ -225,9 +93,8 @@ class Org {
 
   draw() {
 
-    var baseColor = this.baseColor;
-    var cytoColor = this.cytoColor;   
-
+    let baseColor = this.baseColor;
+    let cytoColor = this.cytoColor;   
 
     let p = this.p;
     p.fill(cytoColor)
@@ -257,6 +124,135 @@ class Org {
       }
     }
 
+  }
+
+  static
+    getNewGenes() {
+    let numSegments = randNumGenes(); // Get the number of gene segments to create.
+
+    let genes = { // Setup inital genes object
+      numSegments: numSegments,
+      segments: new Array(numSegments)
+    }
+
+    let gene = null, n = 0; // Getting the rest of the genes.
+    while (n < numSegments - 1) {
+      gene = randGeneColor();
+      if (true || gene == genes.segments[0].color || !baseColors.has(gene)) { // Currently disabled
+        genes.segments[n] = { color: gene, length: randGeneLength() };
+        n += 1;
+      }
+    }
+    genes.segments[n] = {
+      color: randBaseGeneColor(),
+      length: randGeneLength()
+    }
+
+    genes['totalGenesLength'] = genes.segments  // Get total genes length;
+      .reduce((total, gene) => total + gene.length, 0)
+
+    genes['avgGeneArea'] = Math.sqrt(genes.segments // Get avg gene area.
+      .reduce((total, gene) => total + gene.length * gene.length, 0))
+
+    return genes;
+  }
+
+  static
+    getNewNucleus(x, y, org) {
+    let avgGeneArea = org.genes.avgGeneArea
+    let bodyRadius = avgGeneArea * 2 < minBodySize ? minBodySize : avgGeneArea;
+    bodyRadius = cellScale * bodyRadius;
+
+    return {
+      body: MJSW.addCircle(
+        {
+          x: x, y: y, r: bodyRadius,
+          composite: org.composite, owner: org,
+          options: { ...cellBodyDefaults, label: 'nucleus' }
+        }
+      ),
+      r: bodyRadius
+    }
+  }
+
+  static
+    getNewExpressions(org) {
+    let aggregate = {};
+    for (let i = 0; i < org.genes.numSegments; i++) {
+      let { color, length } = org.genes.segments[i];
+      if (color in aggregate) {
+        aggregate[color].length += length;
+        aggregate[color].n += 1;
+      }
+      else {
+        aggregate[color] = { length: length, n: 1 }
+      }
+    }
+
+    let expressions = {};
+    for (const [color, exp] of Object.entries(aggregate)) {
+      exp.avgLength = exp.length / exp.n;
+      let expBody = MJSW.addCircle({
+        x: org.nucleus.body.position.x,
+        y: org.nucleus.body.position.y,
+        r: cellScale * exp.avgLength,
+        composite: org.composite, owner: org,
+        options: { mass: 0, label: 'expression-' + color }
+      })
+
+      // we need to get the rest of the object...
+      let completeExp = newExpression(color, exp, expBody, org);
+      expressions[color] = completeExp;
+    }
+
+    return expressions;
+  }
+
+  static
+    getNewWall(org) {
+    let offset = 5;
+    let r = Math.max(...Object.values(org.expressions)
+      .map(exp => exp.avgLength)) + org.nucleus.r + offset + 5;
+
+    let [segments, constraints] = MJSW.addSoftCircle({
+      x: org.nucleus.body.position.x,
+      y: org.nucleus.body.position.y,
+      r: r,
+      owner: org, composite: org.composite,
+      ...wallDefaults
+    })
+
+    let wall = {
+      segments: segments,
+      constraints: constraints,
+      r: r,
+    }
+
+    return wall;
+  }
+
+  static
+    getNewDefaultState(org) {
+    let passive = {};
+    let active = {};
+    for (let exp of Object.values(org.expressions)) {
+      passive = Object.assign({}, passive, exp.activation.passive);
+      active = Object.assign({}, active, exp.activation.active);
+    }
+    return { active: active, passive: passive };
+  }
+
+  static
+    orgEvent(orgA, orgB) {
+
+    let aE = cloneDeep(orgA.defaultState.active);
+    let bE = cloneDeep(orgB.defaultState.active);
+
+    for (let activation of Object.values(aE)) activation.setup(orgB, bE);
+    for (let activation of Object.values(bE)) activation.setup(orgA, aE);
+
+    orgA.activeEvents.push(...Object.values(aE));
+    orgB.activeEvents.push(...Object.values(bE));
   }
 
 }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
     "concurrently": "^5.1.0",
     "nodemon": "^2.0.2"
   },
+  "engines": {
+    "node": ">=10.0.0",
+    "npm": ">=6.0.0"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "client-install": "npm install --prefix client",
@@ -26,6 +30,6 @@
     "url": "git+https://github.com/stkterry/lex-cells.git"
   },
   "keywords": [],
-  "author": "",
-  "license": "ISC"
+  "author": "StevenKT",
+  "license": "GPLv3"
 }

--- a/package.json
+++ b/package.json
@@ -31,5 +31,5 @@
   },
   "keywords": [],
   "author": "StevenKT",
-  "license": "GPLv3"
+  "license": "LGPLv3"
 }


### PR DESCRIPTION
Abstract MJSWrapper from OrgEnv, Org, expressions

MJSWrapper was previously initialized on the org environment
itself and stored on each individual org as well.  References to the
wrapper where removed from all class instances and instead a single,
pre-initialized wrapper instance is being exported from MJSWrapper.
This instance is imported as MJSW in any file that needs it and called
on directly.

The Org methods that are responsible for generating the org in the
constructor have been converted to static class methods and packaged
into a final single static method call in Org.

Assorted/Brief:
Remove MJSWrapper refs and create single instance export,
Convert Org gen methods to static and unify in single static method,
Add engine requirements to client/server package.json,
Add license type to client/server package.json,
Adjust timing for better consistency in p5 orgTest.js,
Add the following methods to MJSWrapper
  - eventsOn, setGravityY, smoothUpdate

Change the following static methods to instance on MJSWrapper
  - getApplyForceToCenter, setVelocity

Note: This message is copied from a previous commit in branch and highlights the
key changes made in this branch overall.